### PR TITLE
Allow level designers to override Classify

### DIFF
--- a/cl_dll/hl/hl_baseentity.cpp
+++ b/cl_dll/hl/hl_baseentity.cpp
@@ -162,6 +162,8 @@ void CBaseMonster :: MonsterInitThink ( void ) { }
 void CBaseMonster :: StartMonster ( void ) { }
 void CBaseMonster :: MovementComplete( void ) { }
 int CBaseMonster::TaskIsRunning( void ) { return 0; }
+int CBaseMonster::Classify( void ) { return 0; }
+void CBaseMonster::SetClassify( int ) { }
 int CBaseMonster::IRelationship ( CBaseEntity *pTarget ) { return 0; }
 BOOL CBaseMonster :: FindCover ( Vector vecThreat, Vector vecViewOffset, float flMinDist, float flMaxDist ) { return FALSE; }
 BOOL CBaseMonster :: BuildNearestRoute ( Vector vecThreat, Vector vecViewOffset, float flMinDist, float flMaxDist ) { return FALSE; }

--- a/dlls/monster/CAGrunt.cpp
+++ b/dlls/monster/CAGrunt.cpp
@@ -100,12 +100,17 @@ const char *CAGrunt::pAlertSounds[] =
 //=========================================================
 int CAGrunt::IRelationship ( CBaseEntity *pTarget )
 {
-	if ( FClassnameIs( pTarget->pev, "monster_human_grunt" ) )
+	// Only override if there is at least a dislike relationship already,
+	// because level designers may override the class.
+
+	int r = CTalkSquadMonster :: IRelationship( pTarget );
+
+	if ( (r >= R_DL) && FClassnameIs( pTarget->pev, "monster_human_grunt" ) )
 	{
 		return R_NM;
 	}
-
-	return CTalkSquadMonster :: IRelationship( pTarget );
+	else
+		return r;
 }
 
 //=========================================================

--- a/dlls/monster/CAGrunt.cpp
+++ b/dlls/monster/CAGrunt.cpp
@@ -303,7 +303,7 @@ void CAGrunt :: PainSound ( void )
 //=========================================================
 int	CAGrunt :: Classify ( void )
 {
-	return	CLASS_ALIEN_MILITARY;
+	return	m_Classify ? CBaseMonster::Classify() : CLASS_ALIEN_MILITARY;
 }
 
 //=========================================================

--- a/dlls/monster/CApache.cpp
+++ b/dlls/monster/CApache.cpp
@@ -33,7 +33,7 @@ class CApache : public CBaseMonster
 
 	void Spawn( void );
 	void Precache( void );
-	int  Classify( void ) { return CLASS_HUMAN_MILITARY; };
+	int  Classify( void ) { return m_Classify ? CBaseMonster::Classify() : CLASS_HUMAN_MILITARY; };
 	int  BloodColor( void ) { return DONT_BLEED; }
 	void Killed( entvars_t *pevAttacker, int iGib );
 	void GibMonster( void );

--- a/dlls/monster/CBabyVoltigore.cpp
+++ b/dlls/monster/CBabyVoltigore.cpp
@@ -94,7 +94,7 @@ const char* CBabyVoltigore::pRunSounds[] =
 
 int	CBabyVoltigore::Classify(void)
 {
-	return CLASS_ALIEN_MONSTER;
+	return m_Classify ? CBaseMonster::Classify() : CLASS_ALIEN_MONSTER;
 }
 
 void CBabyVoltigore::SetYawSpeed(void)

--- a/dlls/monster/CBarney.cpp
+++ b/dlls/monster/CBarney.cpp
@@ -261,7 +261,11 @@ int CBarney :: ISoundMask ( void)
 //=========================================================
 int	CBarney :: Classify ( void )
 {
-	return	m_Classify ? CTalkSquadMonster::Classify() : CLASS_PLAYER_ALLY;
+	// Is Player Ally? works inverted for friendly monsters
+	if (m_IsPlayerAlly)
+		return CLASS_HUMAN_MILITARY;
+	else
+		return m_Classify ? CTalkSquadMonster::Classify() : CLASS_PLAYER_ALLY;
 }
 
 //=========================================================

--- a/dlls/monster/CBarney.cpp
+++ b/dlls/monster/CBarney.cpp
@@ -261,7 +261,7 @@ int CBarney :: ISoundMask ( void)
 //=========================================================
 int	CBarney :: Classify ( void )
 {
-	return	CLASS_PLAYER_ALLY;
+	return	m_Classify ? CTalkSquadMonster::Classify() : CLASS_PLAYER_ALLY;
 }
 
 //=========================================================

--- a/dlls/monster/CBaseGrunt.cpp
+++ b/dlls/monster/CBaseGrunt.cpp
@@ -533,7 +533,7 @@ void CBaseGrunt :: CheckAmmo ( void )
 
 int	CBaseGrunt :: Classify ( void )
 {
-	return	CLASS_HUMAN_MILITARY;
+	return	m_Classify ? CBaseMonster::Classify() : CLASS_HUMAN_MILITARY;
 }
 
 CBaseEntity *CBaseGrunt :: Kick( void )

--- a/dlls/monster/CBaseGrunt.cpp
+++ b/dlls/monster/CBaseGrunt.cpp
@@ -65,12 +65,17 @@ void CBaseGrunt :: SpeakSentence( void )
 
 int CBaseGrunt::IRelationship ( CBaseEntity *pTarget )
 {
-	if ( FClassnameIs( pTarget->pev, "monster_alien_grunt" ) || ( FClassnameIs( pTarget->pev,  "monster_gargantua" ) ) )
+	// Only override if there is at least a dislike relationship already,
+	// because level designers may override the class.
+
+	int r = CTalkSquadMonster :: IRelationship( pTarget );
+
+	if ( (r >= R_DL) && ( FClassnameIs( pTarget->pev, "monster_alien_grunt" ) || ( FClassnameIs( pTarget->pev,  "monster_gargantua" ) ) ) )
 	{
 		return R_NM;
 	}
-
-	return CTalkSquadMonster::IRelationship( pTarget );
+	else
+		return r;
 }
 
 void CBaseGrunt :: GibMonster ( void )

--- a/dlls/monster/CBaseGruntOp4.cpp
+++ b/dlls/monster/CBaseGruntOp4.cpp
@@ -43,7 +43,11 @@ void CBaseGruntOp4::PlaySentenceSound(int sentenceType) {
 
 int	CBaseGruntOp4::Classify(void)
 {
-	return	m_Classify ? CBaseMonster::Classify() : CLASS_PLAYER_ALLY;
+	// Is Player Ally? works inverted for friendly monsters
+	if (m_IsPlayerAlly)
+		return CLASS_HUMAN_MILITARY;
+	else
+		return m_Classify ? CTalkSquadMonster::Classify() : CLASS_PLAYER_ALLY;
 }
 
 int CBaseGruntOp4::ISoundMask(void)

--- a/dlls/monster/CBaseGruntOp4.cpp
+++ b/dlls/monster/CBaseGruntOp4.cpp
@@ -43,7 +43,7 @@ void CBaseGruntOp4::PlaySentenceSound(int sentenceType) {
 
 int	CBaseGruntOp4::Classify(void)
 {
-	return	CLASS_PLAYER_ALLY;
+	return	m_Classify ? CBaseMonster::Classify() : CLASS_PLAYER_ALLY;
 }
 
 int CBaseGruntOp4::ISoundMask(void)

--- a/dlls/monster/CBaseMonster.cpp
+++ b/dlls/monster/CBaseMonster.cpp
@@ -25,6 +25,7 @@
 // to just pick a new one when we start up again.
 TYPEDESCRIPTION	CBaseMonster::m_SaveData[] =
 {
+	DEFINE_FIELD(CBaseMonster, m_Classify, FIELD_INTEGER ),
 	DEFINE_FIELD(CBaseMonster, m_hEnemy, FIELD_EHANDLE),
 	DEFINE_FIELD(CBaseMonster, m_hTargetEnt, FIELD_EHANDLE),
 	DEFINE_ARRAY(CBaseMonster, m_hOldEnemy, FIELD_EHANDLE, MAX_OLD_ENEMIES),
@@ -2181,6 +2182,27 @@ int CBaseMonster::TaskIsRunning(void)
 }
 
 //=========================================================
+// Classify - indicates this monster's place in the
+// relationship table.
+//=========================================================
+int	CBaseMonster :: Classify ( void )
+{
+	return m_Classify;
+}
+
+//=========================================================
+// SetClassify - sets/changes the monster's classify and
+// clears its current schedule to make it pick a new target
+// according to its new class.
+//=========================================================
+void CBaseMonster::SetClassify ( int iNewClassify )
+{
+	m_Classify = iNewClassify;
+	ClearSchedule();
+	m_hEnemy = NULL;
+}
+
+//=========================================================
 // IRelationship - returns an integer that describes the 
 // relationship between two types of monster.
 //=========================================================
@@ -2962,7 +2984,12 @@ void CBaseMonster::ReportAIState(void)
 //=========================================================
 void CBaseMonster::KeyValue(KeyValueData* pkvd)
 {
-	if (FStrEq(pkvd->szKeyName, "TriggerTarget"))
+	if (FStrEq(pkvd->szKeyName, "classify"))
+	{
+		SetClassify(atoi(pkvd->szValue));
+		pkvd->fHandled = TRUE;
+	}
+	else if (FStrEq(pkvd->szKeyName, "TriggerTarget"))
 	{
 		m_iszTriggerTarget = ALLOC_STRING(pkvd->szValue);
 		pkvd->fHandled = TRUE;

--- a/dlls/monster/CBaseMonster.cpp
+++ b/dlls/monster/CBaseMonster.cpp
@@ -26,6 +26,7 @@
 TYPEDESCRIPTION	CBaseMonster::m_SaveData[] =
 {
 	DEFINE_FIELD(CBaseMonster, m_Classify, FIELD_INTEGER ),
+	DEFINE_FIELD(CBaseMonster, m_IsPlayerAlly, FIELD_BOOLEAN ),
 	DEFINE_FIELD(CBaseMonster, m_hEnemy, FIELD_EHANDLE),
 	DEFINE_FIELD(CBaseMonster, m_hTargetEnt, FIELD_EHANDLE),
 	DEFINE_ARRAY(CBaseMonster, m_hOldEnemy, FIELD_EHANDLE, MAX_OLD_ENEMIES),
@@ -2986,7 +2987,16 @@ void CBaseMonster::KeyValue(KeyValueData* pkvd)
 {
 	if (FStrEq(pkvd->szKeyName, "classify"))
 	{
-		SetClassify(atoi(pkvd->szValue));
+		// Is Player Ally? overrides Classify and we don't know which keyvalue is handled first
+		if (!m_IsPlayerAlly)
+			SetClassify(atoi(pkvd->szValue));
+		pkvd->fHandled = TRUE;
+	}
+	else if (FStrEq(pkvd->szKeyName, "is_player_ally"))
+	{
+		m_IsPlayerAlly = atoi(pkvd->szValue);
+		if (m_IsPlayerAlly)
+			SetClassify(CLASS_PLAYER_ALLY);
 		pkvd->fHandled = TRUE;
 	}
 	else if (FStrEq(pkvd->szKeyName, "TriggerTarget"))

--- a/dlls/monster/CBaseMonster.cpp
+++ b/dlls/monster/CBaseMonster.cpp
@@ -2941,14 +2941,109 @@ void CBaseMonster::ReportAIState(void)
 	else
 		ALERT(level, "No enemy");
 
+	ALERT( level, "\nClassify: " );
+	switch( Classify() )
+	{
+		case 0:
+			{
+				ALERT( level, "None" );
+				break;
+			}
+		case 1:
+			{
+				ALERT( level, "Machine" );
+				break;
+			}
+		case 2:
+			{
+				ALERT( level, "Black Mesa - Player" );
+				break;
+			}
+		case 11:
+			{
+				ALERT( level, "Black Mesa - Player Ally" );
+				break;
+			}
+		case 3:
+			{
+				ALERT( level, "Black Mesa - Human Passive" );
+				break;
+			}
+		case 4:
+			{
+				ALERT( level, "Human Military Force" );
+				break;
+			}
+		case 5:
+			{
+				ALERT( level, "Alien - Military" );
+				break;
+			}
+		case 6:
+			{
+				ALERT( level, "Alien - Passive" );
+				break;
+			}
+		case 7:
+			{
+				ALERT( level, "Alien - Monster" );
+				break;
+			}
+		case 8:
+			{
+				ALERT( level, "Alien - Prey" );
+				break;
+			}
+		case 9:
+			{
+				ALERT( level, "Alien - Predator" );
+				break;
+			}
+		case 10:
+			{
+				ALERT( level, "Insect" );
+				break;
+			}
+		case 12:
+			{
+				ALERT( level, "Bioweapon - Player" );
+				break;
+			}
+		case 13:
+			{
+				ALERT( level, "Bioweapon - Alien" );
+				break;
+			}
+		case 14:
+			{
+				ALERT( level, "Human Military Force - Friendly" );
+				break;
+			}
+		case 15:
+			{
+				ALERT( level, "Alien - Race X" );
+				break;
+			}
+		case 99:
+			{
+				ALERT( level, "Barnacle" );
+				break;
+			}
+		default:
+			ALERT( level, "Unknown - %d", Classify() );
+	}
+	if (m_IsPlayerAlly)
+		ALERT( level, "\n\tPlayer Ally set!" );
+
 	if (IsMoving())
 	{
-		ALERT(level, " Moving ");
+		ALERT(level, "\n Moving ");
 		if (m_flMoveWaitFinished > gpGlobals->time)
 			ALERT(level, ": Stopped for %.2f. ", m_flMoveWaitFinished - gpGlobals->time);
 		else if (m_IdealActivity == GetStoppedActivity())
 			ALERT(level, ": In stopped anim. ");
 	}
+	ALERT( level, "\n" );
 
 	CTalkSquadMonster* pSquadMonster = MyTalkSquadMonsterPointer();
 

--- a/dlls/monster/CBaseMonster.h
+++ b/dlls/monster/CBaseMonster.h
@@ -43,6 +43,7 @@ public:
 
 	
 		// these fields have been added in the process of reworking the state machine. (sjb)
+		int				m_Classify;		// Classify, to let mappers override the default
 		EHANDLE				m_hEnemy;		 // the entity that the monster is fighting.
 		EHANDLE				m_hTargetEnt;	 // the entity that the monster is trying to reach
 		EHANDLE				m_hOldEnemy[ MAX_OLD_ENEMIES ];
@@ -158,6 +159,8 @@ public:
 // stuff written for new state machine
 		virtual void MonsterThink( void );
 		void EXPORT	CallMonsterThink( void ) { this->MonsterThink(); }
+		virtual int Classify ( void );
+		virtual void SetClassify ( int iNewClassify );
 		virtual int IRelationship ( CBaseEntity *pTarget );
 		virtual void MonsterInit ( void );
 		virtual void MonsterInitDead( void );	// Call after animation/pose is set up

--- a/dlls/monster/CBaseMonster.h
+++ b/dlls/monster/CBaseMonster.h
@@ -44,6 +44,7 @@ public:
 	
 		// these fields have been added in the process of reworking the state machine. (sjb)
 		int				m_Classify;		// Classify, to let mappers override the default
+		BOOL				m_IsPlayerAlly;		// Toggles player ally status (shortcut to override Classify)
 		EHANDLE				m_hEnemy;		 // the entity that the monster is fighting.
 		EHANDLE				m_hTargetEnt;	 // the entity that the monster is trying to reach
 		EHANDLE				m_hOldEnemy[ MAX_OLD_ENEMIES ];

--- a/dlls/monster/CBaseTurret.cpp
+++ b/dlls/monster/CBaseTurret.cpp
@@ -802,6 +802,6 @@ int CBaseTurret::MoveTurret(void)
 int	CBaseTurret::Classify(void)
 {
 	if (m_iOn || m_iAutoStart)
-		return	CLASS_MACHINE;
+		return	m_Classify ? CBaseMonster::Classify() : CLASS_MACHINE;
 	return CLASS_NONE;
 }

--- a/dlls/monster/CBigMomma.cpp
+++ b/dlls/monster/CBigMomma.cpp
@@ -406,7 +406,7 @@ void CBigMomma :: KeyValue( KeyValueData *pkvd )
 //=========================================================
 int	CBigMomma :: Classify ( void )
 {
-	return	CLASS_ALIEN_MONSTER;
+	return	m_Classify ? CBaseMonster::Classify() : CLASS_ALIEN_MONSTER;
 }
 
 //=========================================================

--- a/dlls/monster/CBloater.cpp
+++ b/dlls/monster/CBloater.cpp
@@ -57,7 +57,7 @@ LINK_ENTITY_TO_CLASS( monster_bloater, CBloater );
 //=========================================================
 int	CBloater :: Classify ( void )
 {
-	return	CLASS_ALIEN_MONSTER;
+	return	m_Classify ? CBaseMonster::Classify() : CLASS_ALIEN_MONSTER;
 }
 
 //=========================================================

--- a/dlls/monster/CBodyGuard.cpp
+++ b/dlls/monster/CBodyGuard.cpp
@@ -369,7 +369,7 @@ void CBodyGuard::PlaySentenceSound(int sentenceType) {
 
 int	CBodyGuard::Classify(void)
 {
-	return	CLASS_HUMAN_MILITARY;
+	return	m_Classify ? CBaseMonster::Classify() : CLASS_HUMAN_MILITARY;
 }
 
 int CBodyGuard::ISoundMask(void)

--- a/dlls/monster/CBullsquid.cpp
+++ b/dlls/monster/CBullsquid.cpp
@@ -425,7 +425,7 @@ int CBullsquid :: ISoundMask ( void )
 //=========================================================
 int	CBullsquid :: Classify ( void )
 {
-	return	CLASS_ALIEN_PREDATOR;
+	return	m_Classify ? CBaseMonster::Classify() : CLASS_ALIEN_PREDATOR;
 }
 
 //=========================================================

--- a/dlls/monster/CChumtoad.cpp
+++ b/dlls/monster/CChumtoad.cpp
@@ -31,7 +31,7 @@ public:
 	void PrescheduleThink();
 	void StartTask(Task_t* pTask);
 	Schedule_t* GetScheduleOfType(int Type);
-	
+
 	BOOL CheckRangeAttack1(float flDot, float flDist) { return FALSE; }
 	BOOL CheckRangeAttack2(float flDot, float flDist) { return FALSE; }
 	BOOL CheckMeleeAttack1(float flDot, float flDist);
@@ -75,7 +75,7 @@ void CChumtoad::Precache()
 
 int	CChumtoad::Classify(void)
 {
-	return CLASS_ALIEN_MONSTER;
+	return m_Classify ? CBaseMonster::Classify() : CLASS_ALIEN_MONSTER;
 }
 
 void CChumtoad::SetYawSpeed(void)

--- a/dlls/monster/CController.cpp
+++ b/dlls/monster/CController.cpp
@@ -157,7 +157,7 @@ const char *CController::pDeathSounds[] =
 //=========================================================
 int	CController :: Classify ( void )
 {
-	return	CLASS_ALIEN_MILITARY;
+	return	m_Classify ? CBaseMonster::Classify() : CLASS_ALIEN_MILITARY;
 }
 
 //=========================================================

--- a/dlls/monster/CFurniture.cpp
+++ b/dlls/monster/CFurniture.cpp
@@ -58,9 +58,10 @@ void CFurniture::Spawn()
 }
 
 //=========================================================
-// ID's Furniture as neutral (noone will attack it)
+// ID's Furniture as neutral (noone will attack it, unless
+// overridden)
 //=========================================================
 int CFurniture::Classify(void)
 {
-	return	CLASS_NONE;
+	return	m_Classify ? CBaseMonster::Classify() : CLASS_NONE;
 }

--- a/dlls/monster/CGMan.cpp
+++ b/dlls/monster/CGMan.cpp
@@ -69,7 +69,7 @@ IMPLEMENT_SAVERESTORE( CGMan, CBaseMonster );
 //=========================================================
 int	CGMan :: Classify ( void )
 {
-	return	CLASS_NONE;
+	return	m_Classify ? CBaseMonster::Classify() : CLASS_NONE;
 }
 
 //=========================================================

--- a/dlls/monster/CGargantua.cpp
+++ b/dlls/monster/CGargantua.cpp
@@ -483,7 +483,7 @@ void CGargantua :: PrescheduleThink( void )
 //=========================================================
 int	CGargantua :: Classify ( void )
 {
-	return	CLASS_ALIEN_MONSTER;
+	return	m_Classify ? CBaseMonster::Classify() : CLASS_ALIEN_MONSTER;
 }
 
 //=========================================================

--- a/dlls/monster/CGenericMonster.cpp
+++ b/dlls/monster/CGenericMonster.cpp
@@ -47,7 +47,7 @@ LINK_ENTITY_TO_CLASS( monster_generic, CGenericMonster );
 //=========================================================
 int	CGenericMonster :: Classify ( void )
 {
-	return	CLASS_PLAYER_ALLY;
+	return	m_Classify ? CBaseMonster::Classify() : CLASS_PLAYER_ALLY;
 }
 
 //=========================================================

--- a/dlls/monster/CGonome.cpp
+++ b/dlls/monster/CGonome.cpp
@@ -134,7 +134,7 @@ const char* CGonome::pEventSounds[] =
 
 int	CGonome:: Classify ( void )
 {
-	return CLASS_ALIEN_MONSTER;
+	return m_Classify ? CBaseMonster::Classify() : CLASS_ALIEN_MONSTER;
 }
 
 void CGonome:: SetYawSpeed ( void )

--- a/dlls/monster/CHAssassin.cpp
+++ b/dlls/monster/CHAssassin.cpp
@@ -159,7 +159,7 @@ int CHAssassin :: ISoundMask ( void)
 //=========================================================
 int	CHAssassin :: Classify ( void )
 {
-	return	CLASS_HUMAN_MILITARY;
+	return	m_Classify ? CBaseMonster::Classify() : CLASS_HUMAN_MILITARY;
 }
 
 //=========================================================

--- a/dlls/monster/CHGrunt.cpp
+++ b/dlls/monster/CHGrunt.cpp
@@ -173,7 +173,7 @@ void CHGrunt::Precache()
 
 int	CHGrunt::Classify(void)
 {
-	return	CLASS_HUMAN_MILITARY;
+	return	m_Classify ? CBaseMonster::Classify() : CLASS_HUMAN_MILITARY;
 }
 
 void CHGrunt::PainSound(void)

--- a/dlls/monster/CHWGrunt.cpp
+++ b/dlls/monster/CHWGrunt.cpp
@@ -65,7 +65,6 @@ class CHWGrunt : public CBaseGrunt
 public:
 	void Spawn(void);
 	void Precache(void);
-	int Classify(void);
 	void InitAiFlags();
 	void PainSound(void);
 	void DeathSound(void);
@@ -189,11 +188,6 @@ void CHWGrunt::Precache()
 		PRECACHE_SOUND((char*)pDeathSounds[i]);
 
 	BasePrecache();
-}
-
-int	CHWGrunt::Classify(void)
-{
-	return	CLASS_HUMAN_MILITARY;
 }
 
 void CHWGrunt::InitAiFlags() {

--- a/dlls/monster/CHeadCrab.cpp
+++ b/dlls/monster/CHeadCrab.cpp
@@ -156,7 +156,7 @@ const char *CHeadCrab::pBiteSounds[] =
 //=========================================================
 int	CHeadCrab :: Classify ( void )
 {
-	return	CLASS_ALIEN_PREY;
+	return	m_Classify ? CBaseMonster::Classify() : CLASS_ALIEN_PREY;
 }
 
 //=========================================================

--- a/dlls/monster/CHoundeye.cpp
+++ b/dlls/monster/CHoundeye.cpp
@@ -128,7 +128,7 @@ IMPLEMENT_SAVERESTORE( CHoundeye, CTalkSquadMonster );
 //=========================================================
 int	CHoundeye :: Classify ( void )
 {
-	return	CLASS_ALIEN_MONSTER;
+	return	m_Classify ? CBaseMonster::Classify() : CLASS_ALIEN_MONSTER;
 }
 
 //=========================================================

--- a/dlls/monster/CISlave.cpp
+++ b/dlls/monster/CISlave.cpp
@@ -147,7 +147,7 @@ const char *CISlave::pDeathSounds[] =
 //=========================================================
 int	CISlave :: Classify ( void )
 {
-	return	CLASS_ALIEN_MILITARY;
+	return	m_Classify ? CBaseMonster::Classify() : CLASS_ALIEN_MILITARY;
 }
 
 

--- a/dlls/monster/CIchthyosaur.cpp
+++ b/dlls/monster/CIchthyosaur.cpp
@@ -326,7 +326,7 @@ IMPLEMENT_CUSTOM_SCHEDULES(CIchthyosaur, CFlyingMonster);
 //=========================================================
 int	CIchthyosaur :: Classify ( void )
 {
-	return	CLASS_ALIEN_MONSTER;
+	return	m_Classify ? CBaseMonster::Classify() : CLASS_ALIEN_MONSTER;
 }
 
 

--- a/dlls/monster/CLeech.cpp
+++ b/dlls/monster/CLeech.cpp
@@ -110,7 +110,7 @@ public:
 	void Killed( entvars_t *pevAttacker, int iGib );
 	void Activate( void );
 	int TakeDamage( entvars_t *pevInflictor, entvars_t *pevAttacker, float flDamage, int bitsDamageType );
-	int	Classify( void ) { return CLASS_INSECT; }
+	int	Classify( void ) { return m_Classify ? CBaseMonster::Classify() : CLASS_INSECT; }
 	int IRelationship( CBaseEntity *pTarget );
 
 	virtual int		Save( CSave &save );

--- a/dlls/monster/CNihilanth.cpp
+++ b/dlls/monster/CNihilanth.cpp
@@ -34,7 +34,7 @@ public:
 
 	void Spawn( void );
 	void Precache( void );
-	int  Classify( void ) { return CLASS_ALIEN_MILITARY; };
+	int  Classify( void ) { return m_Classify ? CBaseMonster::Classify() : CLASS_ALIEN_MILITARY; };
 	int  BloodColor( void ) { return BLOOD_COLOR_YELLOW; }
 	void Killed( entvars_t *pevAttacker, int iGib );
 	void GibMonster( void );

--- a/dlls/monster/COsprey.cpp
+++ b/dlls/monster/COsprey.cpp
@@ -47,7 +47,7 @@ public:
 	
 	void Spawn( void );
 	void Precache( void );
-	int  Classify( void ) { return CLASS_MACHINE; };
+	int  Classify( void ) { return m_Classify ? CBaseMonster::Classify() : CLASS_MACHINE; };
 	int  BloodColor( void ) { return DONT_BLEED; }
 	void Killed( entvars_t *pevAttacker, int iGib );
 

--- a/dlls/monster/COtis.cpp
+++ b/dlls/monster/COtis.cpp
@@ -300,7 +300,7 @@ int COtis :: ISoundMask ( void)
 //=========================================================
 int	COtis :: Classify ( void )
 {
-	return	CLASS_PLAYER_ALLY;
+	return	m_Classify ? CBaseMonster::Classify() : CLASS_PLAYER_ALLY;
 }
 
 //=========================================================

--- a/dlls/monster/COtis.cpp
+++ b/dlls/monster/COtis.cpp
@@ -300,7 +300,11 @@ int COtis :: ISoundMask ( void)
 //=========================================================
 int	COtis :: Classify ( void )
 {
-	return	m_Classify ? CBaseMonster::Classify() : CLASS_PLAYER_ALLY;
+	// Is Player Ally? works inverted for friendly monsters
+	if (m_IsPlayerAlly)
+		return CLASS_HUMAN_MILITARY;
+	else
+		return m_Classify ? CTalkSquadMonster::Classify() : CLASS_PLAYER_ALLY;
 }
 
 //=========================================================

--- a/dlls/monster/CPitdrone.cpp
+++ b/dlls/monster/CPitdrone.cpp
@@ -409,7 +409,7 @@ int CPitdrone :: ISoundMask ( void )
 //=========================================================
 int	CPitdrone :: Classify ( void )
 {
-	return	CLASS_ALIEN_PREDATOR;
+	return	m_Classify ? CBaseMonster::Classify() : CLASS_ALIEN_PREDATOR;
 }
 
 //=========================================================

--- a/dlls/monster/CPitdrone.cpp
+++ b/dlls/monster/CPitdrone.cpp
@@ -296,8 +296,8 @@ int CPitdrone::IgnoreConditions ( void )
 
 int CPitdrone::IRelationship ( CBaseEntity *pTarget )
 {
-	//Always mark pit drones as allies
-	if ( FClassnameIs ( pTarget->pev, "monster_pitdrone" ) )
+	// Mark pit drones as allies, but only if we're on the same class
+	if ( FClassnameIs ( pTarget->pev, "monster_pitdrone" ) && ( Classify() == pTarget->Classify() ) )
 	{
 		return R_AL;
 	}

--- a/dlls/monster/CRat.cpp
+++ b/dlls/monster/CRat.cpp
@@ -42,7 +42,7 @@ LINK_ENTITY_TO_CLASS( monster_rat, CRat );
 //=========================================================
 int	CRat :: Classify ( void )
 {
-	return	CLASS_INSECT;
+	return	m_Classify ? CBaseMonster::Classify() : CLASS_INSECT;
 }
 
 //=========================================================

--- a/dlls/monster/CRoach.cpp
+++ b/dlls/monster/CRoach.cpp
@@ -75,7 +75,7 @@ int CRoach :: ISoundMask ( void )
 //=========================================================
 int	CRoach :: Classify ( void )
 {
-	return CLASS_INSECT;
+	return m_Classify ? CBaseMonster::Classify() : CLASS_INSECT;
 }
 
 //=========================================================

--- a/dlls/monster/CScientist.cpp
+++ b/dlls/monster/CScientist.cpp
@@ -574,7 +574,11 @@ void CScientist :: RunTask( Task_t *pTask )
 //=========================================================
 int	CScientist :: Classify ( void )
 {
-	return	m_Classify ? CBaseMonster::Classify() : CLASS_HUMAN_PASSIVE;
+	// Is Player Ally? works inverted for friendly monsters
+	if (m_IsPlayerAlly)
+		return CLASS_HUMAN_MILITARY;
+	else
+		return m_Classify ? CTalkSquadMonster::Classify() : CLASS_HUMAN_PASSIVE;
 }
 
 

--- a/dlls/monster/CScientist.cpp
+++ b/dlls/monster/CScientist.cpp
@@ -574,7 +574,7 @@ void CScientist :: RunTask( Task_t *pTask )
 //=========================================================
 int	CScientist :: Classify ( void )
 {
-	return	CLASS_HUMAN_PASSIVE;
+	return	m_Classify ? CBaseMonster::Classify() : CLASS_HUMAN_PASSIVE;
 }
 
 
@@ -1245,7 +1245,7 @@ void CSittingScientist :: Precache( void )
 //=========================================================
 int	CSittingScientist :: Classify ( void )
 {
-	return	CLASS_HUMAN_PASSIVE;
+	return	m_Classify ? CBaseMonster::Classify() : CLASS_HUMAN_PASSIVE;
 }
 
 

--- a/dlls/monster/CShockRoach.cpp
+++ b/dlls/monster/CShockRoach.cpp
@@ -169,7 +169,7 @@ const char *COFShockRoach::pBiteSounds[] =
 //=========================================================
 int	COFShockRoach :: Classify ( void )
 {
-	return	CLASS_ALIEN_PREY;
+	return	m_Classify ? CBaseMonster::Classify() : CLASS_ALIEN_PREY;
 }
 
 //=========================================================

--- a/dlls/monster/CShockTrooper.cpp
+++ b/dlls/monster/CShockTrooper.cpp
@@ -286,10 +286,12 @@ void CShockTrooper :: SpeakSentence( void )
 //=========================================================
 int CShockTrooper::IRelationship ( CBaseEntity *pTarget )
 {
-	if ( FClassnameIs( pTarget->pev, "monster_alien_grunt" ) || ( FClassnameIs( pTarget->pev,  "monster_gargantua" ) ) )
-	{
-		return R_NM;
-	}
+	// TODO: This is clearly just copied from Human Grunt and may not really apply to Shock Trooper.
+	// Should the Shock Trooper have nemeses or just don't override this method at all?
+	//if ( FClassnameIs( pTarget->pev, "monster_alien_grunt" ) || ( FClassnameIs( pTarget->pev,  "monster_gargantua" ) ) )
+	//{
+	//	return R_NM;
+	//}
 
 	return CTalkSquadMonster::IRelationship( pTarget );
 }

--- a/dlls/monster/CShockTrooper.cpp
+++ b/dlls/monster/CShockTrooper.cpp
@@ -746,7 +746,7 @@ void CShockTrooper :: CheckAmmo ( void )
 //=========================================================
 int	CShockTrooper :: Classify ( void )
 {
-	return CLASS_ALIEN_RACE_X;
+	return m_Classify ? CBaseMonster::Classify() : CLASS_ALIEN_RACE_X;
 }
 
 //=========================================================

--- a/dlls/monster/CTentacle.cpp
+++ b/dlls/monster/CTentacle.cpp
@@ -241,7 +241,7 @@ typedef enum
 //=========================================================
 int	CTentacle :: Classify ( void )
 {
-	return	CLASS_ALIEN_MONSTER;
+	return	m_Classify ? CBaseMonster::Classify() : CLASS_ALIEN_MONSTER;
 }
 
 //

--- a/dlls/monster/CTor.cpp
+++ b/dlls/monster/CTor.cpp
@@ -210,7 +210,7 @@ IMPLEMENT_CUSTOM_SCHEDULES(CTor, CBaseMonster);
 
 int	CTor::Classify(void)
 {
-	return CLASS_ALIEN_MONSTER;
+	return m_Classify ? CBaseMonster::Classify() : CLASS_ALIEN_MONSTER;
 }
 
 void CTor::SetYawSpeed(void)

--- a/dlls/monster/CTor.cpp
+++ b/dlls/monster/CTor.cpp
@@ -210,7 +210,7 @@ IMPLEMENT_CUSTOM_SCHEDULES(CTor, CBaseMonster);
 
 int	CTor::Classify(void)
 {
-	return m_Classify ? CBaseMonster::Classify() : CLASS_ALIEN_MONSTER;
+	return m_Classify ? CBaseMonster::Classify() : CLASS_ALIEN_MILITARY;
 }
 
 void CTor::SetYawSpeed(void)

--- a/dlls/monster/CVoltigore.cpp
+++ b/dlls/monster/CVoltigore.cpp
@@ -152,7 +152,7 @@ const char* CVoltigore::pEventSounds[] =
 
 int	CVoltigore::Classify(void)
 {
-	return CLASS_ALIEN_MONSTER;
+	return m_Classify ? CBaseMonster::Classify() : CLASS_ALIEN_MONSTER;
 }
 
 void CVoltigore::SetYawSpeed(void)

--- a/dlls/monster/CZombie.cpp
+++ b/dlls/monster/CZombie.cpp
@@ -112,7 +112,7 @@ const char *CZombie::pPainSounds[] =
 //=========================================================
 int	CZombie :: Classify ( void )
 {
-	return	CLASS_ALIEN_MONSTER;
+	return	m_Classify ? CBaseMonster::Classify() : CLASS_ALIEN_MONSTER;
 }
 
 //=========================================================


### PR DESCRIPTION
Honor the "classify" and "is_player_ally" keyvalues. In single player mode (which is not removed yet and might be good for testing), these values get saved.
As for Classify, I actually implemented most of this for my own mod in the 2000s (mine was slightly different that Sven Co-op's approach).