### PR TITLE
Fixes & tweaks

### DIFF
--- a/cl_dll/ammohistory.h
+++ b/cl_dll/ammohistory.h
@@ -125,6 +125,7 @@ public:
 	void Reset( void )
 	{
 		memset( rgAmmoHistory, 0, sizeof rgAmmoHistory );
+		iCurrentHistorySlot = 0;
 	}
 
 	int iHistoryGap;

--- a/dlls/env/CEnvShooter.cpp
+++ b/dlls/env/CEnvShooter.cpp
@@ -8,12 +8,14 @@
 #include "shake.h"
 #include "CGibShooter.h"
 
+#define SF_ENVSHOOTER_DONT_WAIT_TILL_LAND 4
+
 class CEnvShooter : public CGibShooter
 {
 	void		Precache(void);
 	void		KeyValue(KeyValueData* pkvd);
 
-	CGib* CreateGib(void);
+	CGib *CreateGib( float lifeTime );
 };
 
 LINK_ENTITY_TO_CLASS(env_shooter, CEnvShooter)
@@ -67,11 +69,20 @@ void CEnvShooter::Precache(void)
 }
 
 
-CGib* CEnvShooter::CreateGib(void)
+CGib *CEnvShooter::CreateGib( float lifeTime )
 {
 	CGib* pGib = GetClassPtr((CGib*)NULL);
+	if (!pGib)
+		return NULL;
 
 	pGib->Spawn(STRING(pev->model));
+	pGib->m_lifeTime = lifeTime;
+
+	if (FBitSet(pev->spawnflags, SF_ENVSHOOTER_DONT_WAIT_TILL_LAND))
+	{
+		pGib->SetThink( &CGib::StartFadeOut );
+		pGib->pev->nextthink = gpGlobals->time + lifeTime;
+	}
 
 	int bodyPart = 0;
 

--- a/dlls/env/CGib.cpp
+++ b/dlls/env/CGib.cpp
@@ -242,7 +242,8 @@ void CGib::WaitTillLand(void)
 		return;
 	}
 
-	if( pev->velocity == g_vecZero || (m_startFadeTime != 0 && m_startFadeTime <= gpGlobals->time) )
+	if( pev->velocity == g_vecZero ||
+		(m_bornTime + m_lifeTime + 10 <= gpGlobals->time) ) // start fading even if gib had not stopped moving at this time. This is to prevent gibs endlessly rotating on edges
 	{
 		SetThink(&CGib::SUB_StartFadeOut);
 		if (pev->velocity == g_vecZero)
@@ -356,10 +357,24 @@ void CGib::Spawn(const char* szGibModel)
 
 	pev->nextthink = gpGlobals->time + 4;
 	m_lifeTime = 10;
-	m_startFadeTime = gpGlobals->time + 35;
+	m_bornTime = gpGlobals->time;
 	SetThink(&CGib::WaitTillLand);
 	SetTouch(&CGib::BounceGibTouch);
 
 	m_material = matNone;
 	m_cBloodDecals = 5;// how many blood decals this gib can place (1 per bounce until none remain). 
+}
+
+void CGib::StartFadeOut()
+{
+	if( pev->rendermode == kRenderNormal )
+	{
+		pev->renderamt = 255;
+		pev->rendermode = kRenderTransTexture;
+	}
+
+	pev->avelocity = g_vecZero;
+
+	pev->nextthink = gpGlobals->time + 0.1f;
+	SetThink( &CBaseEntity::SUB_FadeOut );
 }

--- a/dlls/env/CGib.cpp
+++ b/dlls/env/CGib.cpp
@@ -242,10 +242,13 @@ void CGib::WaitTillLand(void)
 		return;
 	}
 
-	if (pev->velocity == g_vecZero)
+	if( pev->velocity == g_vecZero || (m_startFadeTime != 0 && m_startFadeTime <= gpGlobals->time) )
 	{
 		SetThink(&CGib::SUB_StartFadeOut);
-		pev->nextthink = gpGlobals->time + m_lifeTime;
+		if (pev->velocity == g_vecZero)
+			pev->nextthink = gpGlobals->time + m_lifeTime;
+		else
+			pev->nextthink = gpGlobals->time;
 
 		// If you bleed, you stink!
 		if (m_bloodColor != DONT_BLEED)
@@ -353,6 +356,7 @@ void CGib::Spawn(const char* szGibModel)
 
 	pev->nextthink = gpGlobals->time + 4;
 	m_lifeTime = 10;
+	m_startFadeTime = gpGlobals->time + 35;
 	SetThink(&CGib::WaitTillLand);
 	SetTouch(&CGib::BounceGibTouch);
 

--- a/dlls/env/CGibShooter.cpp
+++ b/dlls/env/CGibShooter.cpp
@@ -92,13 +92,14 @@ void CGibShooter::Spawn(void)
 }
 
 
-CGib* CGibShooter::CreateGib(void)
+CGib *CGibShooter::CreateGib( float lifeTime )
 {
 	if (CVAR_GET_FLOAT("violence_hgibs") == 0)
 		return NULL;
 
 	CGib* pGib = GetClassPtr((CGib*)NULL);
 	pGib->Spawn("models/hgibs.mdl");
+	pGib->m_lifeTime = lifeTime;
 	pGib->m_bloodColor = BLOOD_COLOR_RED;
 
 	if (pev->body <= 1)
@@ -125,7 +126,8 @@ void CGibShooter::ShootThink(void)
 	vecShootDir = vecShootDir + gpGlobals->v_up * RANDOM_FLOAT(-1, 1) * m_flVariance;;
 
 	vecShootDir = vecShootDir.Normalize();
-	CGib* pGib = CreateGib();
+	const float lifeTime = ( m_flGibLife * RANDOM_FLOAT( 0.95f, 1.05f ) );	// +/- 5%
+	CGib *pGib = CreateGib(lifeTime);
 
 	if (pGib)
 	{
@@ -137,7 +139,6 @@ void CGibShooter::ShootThink(void)
 
 		float thinkTime = pGib->pev->nextthink - gpGlobals->time;
 
-		pGib->m_lifeTime = (m_flGibLife * RANDOM_FLOAT(0.95, 1.05));	// +/- 5%
 		if (pGib->m_lifeTime < thinkTime)
 		{
 			pGib->pev->nextthink = gpGlobals->time + pGib->m_lifeTime;

--- a/dlls/env/CGibShooter.h
+++ b/dlls/env/CGibShooter.h
@@ -12,7 +12,7 @@ public:
 	void EXPORT ShootThink(void);
 	void Use(CBaseEntity* pActivator, CBaseEntity* pCaller, USE_TYPE useType, float value);
 
-	virtual CGib* CreateGib(void);
+	virtual CGib *CreateGib( float lifeTime );
 
 	virtual int		Save(CSave& save);
 	virtual int		Restore(CRestore& restore);

--- a/dlls/monster/CApache.cpp
+++ b/dlls/monster/CApache.cpp
@@ -1189,7 +1189,7 @@ void CApacheHVR :: IgniteThink( void  )
 void CApacheHVR :: AccelerateThink( void  )
 {
 	// check world boundaries
-	if (pev->origin.x < -4096 || pev->origin.x > 4096 || pev->origin.y < -4096 || pev->origin.y > 4096 || pev->origin.z < -4096 || pev->origin.z > 4096)
+	if( !IsInWorld() )
 	{
 		UTIL_Remove( this );
 		return;

--- a/dlls/monster/CController.cpp
+++ b/dlls/monster/CController.cpp
@@ -1230,7 +1230,7 @@ void CControllerHeadBall :: HuntThink( void  )
 	UTIL_ELight(entindex(), 0, pev->origin, pev->renderamt / 16, RGBA(255, 255, 255), 2, 0);
 
 	// check world boundaries
-	if (gpGlobals->time - pev->dmgtime > 5 || pev->renderamt < 64 || m_hEnemy == NULL || m_hOwner == NULL || pev->origin.x < -4096 || pev->origin.x > 4096 || pev->origin.y < -4096 || pev->origin.y > 4096 || pev->origin.z < -4096 || pev->origin.z > 4096)
+	if( gpGlobals->time - pev->dmgtime > 5 || pev->renderamt < 64 || m_hEnemy == NULL || m_hOwner == NULL || !IsInWorld() )
 	{
 		SetTouch( NULL );
 		UTIL_Remove( this );

--- a/dlls/monster/CNihilanth.cpp
+++ b/dlls/monster/CNihilanth.cpp
@@ -1413,7 +1413,7 @@ void CNihilanthHVR :: ZapThink( void  )
 	pev->nextthink = gpGlobals->time + 0.05;
 
 	// check world boundaries
-	if (m_hEnemy == NULL ||  pev->origin.x < -4096 || pev->origin.x > 4096 || pev->origin.y < -4096 || pev->origin.y > 4096 || pev->origin.z < -4096 || pev->origin.z > 4096)
+	if( m_hEnemy == NULL || !IsInWorld() )
 	{
 		SetTouch( NULL );
 		UTIL_Remove( this );
@@ -1532,7 +1532,7 @@ void CNihilanthHVR :: TeleportThink( void  )
 	pev->nextthink = gpGlobals->time + 0.1;
 
 	// check world boundaries
-	if (m_hEnemy == NULL || !m_hEnemy->IsAlive() || pev->origin.x < -4096 || pev->origin.x > 4096 || pev->origin.y < -4096 || pev->origin.y > 4096 || pev->origin.z < -4096 || pev->origin.z > 4096)
+	if( m_hEnemy == NULL || !m_hEnemy->IsAlive() || !IsInWorld() )
 	{
 		STOP_SOUND(edict(), CHAN_WEAPON, "x/x_teleattack1.wav" );
 		UTIL_Remove( this );

--- a/dlls/monster/COsprey.cpp
+++ b/dlls/monster/COsprey.cpp
@@ -315,6 +315,8 @@ CBaseMonster *COsprey :: MakeGrunt( Vector vecSrc )
 	if ( tr.pHit && Instance( tr.pHit )->pev->solid != SOLID_BSP) 
 		return NULL;
 
+	Vector spawnAngles = pev->angles;
+	spawnAngles.x = spawnAngles.z = 0;
 	for (int i = 0; i < m_iUnits; i++)
 	{
 		if (m_hGrunt[i] == NULL || !m_hGrunt[i]->IsAlive())
@@ -328,7 +330,7 @@ CBaseMonster *COsprey :: MakeGrunt( Vector vecSrc )
 				keys["is_player_ally"] = "1";
 			}
 
-			pEntity = Create(replenishMonster, vecSrc, pev->angles, true, NULL, keys);
+			pEntity = Create(replenishMonster, vecSrc, spawnAngles, true, NULL, keys);
 			pGrunt = pEntity->MyMonsterPointer( );
 			pGrunt->pev->movetype = MOVETYPE_FLY;
 			pGrunt->pev->velocity = Vector( 0, 0, RANDOM_FLOAT( -196, -128 ) );

--- a/dlls/monster/monsters.h
+++ b/dlls/monster/monsters.h
@@ -162,6 +162,8 @@ public:
 	int		m_cBloodDecals;
 	int		m_material;
 	float	m_lifeTime;
+	// start fading even if gib had not stopped moving at this time. This is to prevent gibs endlessly rotating on edges
+	float m_startFadeTime;
 };
 
 

--- a/dlls/monster/monsters.h
+++ b/dlls/monster/monsters.h
@@ -150,6 +150,7 @@ public:
 	void BounceGibTouch ( CBaseEntity *pOther );
 	void StickyGibTouch ( CBaseEntity *pOther );
 	void WaitTillLand( void );
+	void StartFadeOut ( void );
 	void LimitVelocity( void );
 
 	virtual int	ObjectCaps( void ) { return (CBaseEntity :: ObjectCaps() & ~FCAP_ACROSS_TRANSITION) | FCAP_DONT_SAVE; }
@@ -162,8 +163,7 @@ public:
 	int		m_cBloodDecals;
 	int		m_material;
 	float	m_lifeTime;
-	// start fading even if gib had not stopped moving at this time. This is to prevent gibs endlessly rotating on edges
-	float m_startFadeTime;
+	float	m_bornTime;
 };
 
 

--- a/dlls/player/CBasePlayer.cpp
+++ b/dlls/player/CBasePlayer.cpp
@@ -1354,7 +1354,10 @@ void CBasePlayer::WaterMove()
 	int air;
 
 	if (pev->movetype == MOVETYPE_NOCLIP)
+	{
+		pev->air_finished = gpGlobals->time + AIRTIME;
 		return;
+	}
 
 	if (pev->health < 0)
 		return;

--- a/dlls/triggers/CRuleEntity.h
+++ b/dlls/triggers/CRuleEntity.h
@@ -36,6 +36,7 @@ class CRuleBrushEntity : public CRuleEntity
 {
 public:
 	void		Spawn(void);
+	int ObjectCaps() { return CRuleEntity::ObjectCaps() & ~FCAP_ACROSS_TRANSITION; }
 
 private:
 };


### PR DESCRIPTION
- Prevent forever living gibs
- Add 'Don't wait till land' flag for env_shooter
- Prevent game_zone_player from transitioning across levels to fix Mod_NumForName: not found issue ([FWGS#471](https://github.com/FWGS/hlsdk-portable/pull/471))
- Use IsInWorld() where appropriate
- Reset ammo history slot on HUD reset ([FWGS#460](https://github.com/FWGS/hlsdk-portable/pull/460))
- Remove roll and pitch from grunts spawning from osprey
- Don't play emerge from water sounds when exiting noclip